### PR TITLE
List mappings for each enum type

### DIFF
--- a/lib/array_enum.rb
+++ b/lib/array_enum.rb
@@ -1,6 +1,8 @@
 require "array_enum/version"
 require "array_enum/subset_validator"
 require "array_enum/railtie" if defined?(Rails)
+require "active_support/hash_with_indifferent_access"
+require "active_support/core_ext/string/inflections"
 
 module ArrayEnum
   MISSING_VALUE_MESSAGE = "%{value} is not a valid value for %{attr}".freeze
@@ -9,21 +11,26 @@ module ArrayEnum
   def array_enum(definitions)
     definitions.each do |attr_name, mapping|
       attr_symbol = attr_name.to_sym
+      mapping_hash = ActiveSupport::HashWithIndifferentAccess.new(mapping)
+
+      define_singleton_method(attr_name.to_s.pluralize) do
+        mapping_hash
+      end
 
       define_singleton_method("with_#{attr_name}".to_sym) do |values|
         db_values = Array(values).map do |value|
-          mapping[value.to_s] || raise(ArgumentError, MISSING_VALUE_MESSAGE % {value: value, attr: attr_name})
+          mapping_hash[value] || raise(ArgumentError, MISSING_VALUE_MESSAGE % {value: value, attr: attr_name})
         end
         where("#{attr_name} @> ARRAY[:db_values]", db_values: db_values)
       end
 
       define_method(attr_symbol) do
-        Array(self[attr_symbol]).map { |value| mapping.key(value) }
+        Array(self[attr_symbol]).map { |value| mapping_hash.key(value) }
       end
 
       define_method("#{attr_name}=".to_sym) do |values|
         self[attr_symbol] = Array(values).map do |value|
-          mapping[value.to_s] || raise(ArgumentError, MISSING_VALUE_MESSAGE % {value: value, attr: attr_name})
+          mapping_hash[value] || raise(ArgumentError, MISSING_VALUE_MESSAGE % {value: value, attr: attr_name})
         end.uniq
       end
     end

--- a/test/array_enum_test.rb
+++ b/test/array_enum_test.rb
@@ -61,4 +61,15 @@ class ArrayEnumTest < Minitest::Test
     end
     assert_match(/black is not a valid value for favourite_colors/, error.message)
   end
+
+  def test_lists_values
+    assert_equal User.favourite_colors, {"red"=>1, "blue"=>2, "green"=>3}
+  end
+
+  def test_values_can_be_accessed_indifferently
+    assert_equal User.favourite_colors[:red], 1
+    assert_equal User.favourite_colors[:blue], 2
+    assert_equal User.favourite_colors[:green], 3
+    assert_equal User.favourite_colors["red"], 1
+  end
 end


### PR DESCRIPTION
This PR replicates the functionality in `ActiveRecord::Enum` that allows us to list the mappings of each individual type, documented [here](https://api.rubyonrails.org/v5.2.3/classes/ActiveRecord/Enum.html). 