### PR TITLE
Handle `proc` for `subset` validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ class CreateUser
   attr_accessor :favourite_colors
 
   validates :favourite_colors, subset: ["green", "blue"]
+  # or:
+  # validates :favourite_colors, subset: { in: ->(record) { Color.pluck(:name) } }
 end
 
 CreateUser.new(favourite_colors: ["black"]).valid? # => false

--- a/lib/array_enum/subset_validator.rb
+++ b/lib/array_enum/subset_validator.rb
@@ -3,7 +3,9 @@ require "active_model/validator"
 class ArrayEnum::SubsetValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     wrapped_value = [value].flatten # Handles nil value
-    diff = wrapped_value.reject { |element| delimiter.include?(element) }
+    subset = delimiter.respond_to?(:call) ? delimiter.call(record) : delimiter
+
+    diff = wrapped_value.reject { |element| subset.include?(element) }
 
     unless diff.empty?
       record.errors.add(attribute, :inclusion, options.except(:in, :within).merge!(value: diff))

--- a/test/subset_validator_test.rb
+++ b/test/subset_validator_test.rb
@@ -9,8 +9,21 @@ class SubsetValidatorTest < Minitest::Test
     validates :favourite_colors, subset: ["green", "blue"]
   end
 
+  class CreateUserWithProc
+    include ActiveModel::Model
+
+    attr_accessor :favourite_colors
+
+    validates :favourite_colors, subset: { in: ->(record) { ["green", "blue"] } }
+  end
+
   def test_valid_with_matching_values
     create_user = CreateUser.new(favourite_colors: ["green"])
+    assert create_user.valid?
+  end
+
+  def test_valid_with_matching_proc_values
+    create_user = CreateUserWithProc.new(favourite_colors: ["green"])
     assert create_user.valid?
   end
 
@@ -19,13 +32,28 @@ class SubsetValidatorTest < Minitest::Test
     assert create_user.invalid?
   end
 
+  def test_invalid_without_proc_value
+    create_user = CreateUserWithProc.new
+    assert create_user.invalid?
+  end
+
   def test_valid_without_array
     create_user = CreateUser.new(favourite_colors: "green")
     assert create_user.valid?
   end
 
+  def test_valid_without_proc_array
+    create_user = CreateUserWithProc.new(favourite_colors: "green")
+    assert create_user.valid?
+  end
+
   def test_invalid_when_no_matching_value
     create_user = CreateUser.new(favourite_colors: ["black"])
+    assert create_user.invalid?
+  end
+
+  def test_invalid_when_no_matching_proc_value
+    create_user = CreateUserWithProc.new(favourite_colors: ["black"])
     assert create_user.invalid?
   end
 
@@ -36,8 +64,22 @@ class SubsetValidatorTest < Minitest::Test
     assert_equal expected_error, create_user.errors.details
   end
 
+  def test_error_details_when_proc_invalid
+    create_user = CreateUserWithProc.new(favourite_colors: ["black"])
+    create_user.validate
+    expected_error = {favourite_colors: [{error: :inclusion, value: ["black"]}]}
+    assert_equal expected_error, create_user.errors.details
+  end
+
   def test_error_message_when_invalid
     create_user = CreateUser.new(favourite_colors: ["black"])
+    create_user.validate
+    expected_error = {favourite_colors: ["is not included in the list"]}
+    assert_equal expected_error, create_user.errors.messages
+  end
+
+  def test_error_message_when_proc_invalid
+    create_user = CreateUserWithProc.new(favourite_colors: ["black"])
     create_user.validate
     expected_error = {favourite_colors: ["is not included in the list"]}
     assert_equal expected_error, create_user.errors.messages


### PR DESCRIPTION
Currently, there is no way to specify values inside a `proc`.
This is useful when we want to load authorized values from another model.

```ruby
class Color < ActiveRecord::Base
  attr_accessor :name
end

class CreateUser
  include ActiveModel::Model

  attr_accessor :favourite_colors

  validates :favourite_colors, subset: { in: ->(record) { Color.pluck(:name) } }
end
```