### PR TITLE
Blank values from typical mass assignments should be removed

### DIFF
--- a/lib/array_enum.rb
+++ b/lib/array_enum.rb
@@ -29,7 +29,7 @@ module ArrayEnum
       end
 
       define_method("#{attr_name}=".to_sym) do |values|
-        self[attr_symbol] = Array(values).map do |value|
+        self[attr_symbol] = Array(values).reject(&:blank?).map do |value|
           mapping_hash[value] || raise(ArgumentError, MISSING_VALUE_MESSAGE % {value: value, attr: attr_name})
         end.uniq
       end

--- a/test/array_enum_test.rb
+++ b/test/array_enum_test.rb
@@ -72,4 +72,10 @@ class ArrayEnumTest < Minitest::Test
     assert_equal User.favourite_colors[:green], 3
     assert_equal User.favourite_colors["red"], 1
   end
+
+  def test_blank_values_from_parameter_maps_should_be_filtered
+    params = ActionController::Parameters.new(favourite_colors: ["", "red", "blue"] ).permit( favourite_colors:[] )
+    user = User.create!(params)
+    assert_equal ["red", "blue"], user.favourite_colors
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,6 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "active_record"
+require "action_controller"
 require "array_enum"
 require "minitest/autorun"
 


### PR DESCRIPTION
When using mass assignment for the enum_array attribute, many frontend libraries work around the issue of setting the array to an empty array, by adding and empty string to the beginning of the array. 

This should be filtered out, as it leads to `MISSING_VALUE_MESSAGE` exceptions in the current code.

Maybe this helps someone.