### PR TITLE
ruby 3 compliant

### DIFF
--- a/lib/array_enum/subset_validator.rb
+++ b/lib/array_enum/subset_validator.rb
@@ -8,7 +8,7 @@ class ArrayEnum::SubsetValidator < ActiveModel::EachValidator
     diff = wrapped_value.reject { |element| subset.include?(element) }
 
     unless diff.empty?
-      record.errors.add(attribute, :inclusion, options.except(:in, :within).merge!(value: diff))
+      record.errors.add(attribute, :inclusion, **options.except(:in, :within).merge!(value: diff))
     end
   end
 


### PR DESCRIPTION
In preparation for Ruby 3, kwargs on last params should be unpacked.

This will also remove warnings for Ruby 2.7.x