### PR TITLE
Add `._with_any_of_*` scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ Extension for `ActiveRecord` that adds support for `PostgreSQL` array columns, m
 ### ActiveRecord extension
 
 Database will store integers that after reading will map to string values.
-Additionally scope is generated with `with_` prefix that will query database for any matching passed value.
 
 ```ruby
 ActiveRecord::Schema.define do
@@ -27,13 +26,43 @@ end
 class User < ActiveRecord::Base
   extend ArrayEnum
 
-  array_enum favourite_colors: {"red" => 1, "blue" => 2}
+  array_enum favourite_colors: {"red" => 1, "blue" => 2, "green" => 3}
 end
 
 user = User.create!(favourite_colors: ["red", "green"])
 user.favourite_colors # => ["red", "green"]
-User.favourite_colors # => {"red" => 1, "blue" => 2}
-User.with_favourite_colors("red") # => [user]
+User.favourite_colors # => {"red" => 1, "blue" => 2, "green" => 3}
+```
+
+Several scopes are made available on your model to find records based on a value or an array of values:
+
+```ruby
+user1 = User.create!(favourite_colors: ["red", "green"])
+user2 = User.create!(favourite_colors: ["red"])
+
+# Find a record that has _all_ the provided values in the array enum attribute
+User.with_favourite_colors("red") # => [user1, user2]
+User.with_favourite_colors(%w[red green]) # => [user1]
+User.with_favourite_colors(%w[red blue]) # => []
+User.with_favourite_colors(%w[green blue]) # => []
+
+# Find a record that has the provided values, and _only those values_, in the array enum attribute
+User.only_with_favourite_colors("red") # => [user2]
+User.only_with_favourite_colors(%w[red green]) # => [user1]
+User.only_with_favourite_colors(%w[red blue]) # => []
+User.only_with_favourite_colors(%w[green blue]) # => []
+
+# Find a record that has _at least one_ of the provided values in the array enum attribute
+User.with_any_of_favourite_colors("red") # => [user1, user2]
+User.with_any_of_favourite_colors(%w[red green]) # => [user1, user2]
+User.with_any_of_favourite_colors(%w[red blue]) # => [user1, user2]
+User.with_any_of_favourite_colors(%w[green blue]) # => [user1]
+```
+
+Attempting to find a record with a value that is not in the enum will fail:
+
+```ruby
+User.with_favourite_colors("yellow") # => ArgumentError["yellow is not a valid value for favourite_colors"]
 ```
 
 ### Subset Validator

--- a/lib/array_enum.rb
+++ b/lib/array_enum.rb
@@ -17,7 +17,11 @@ module ArrayEnum
         mapping_hash
       end
 
-      { "with_#{attr_name}" => '@>', "only_with_#{attr_name}" => '=' }.each do |method_name, comparison_operator|
+      {
+        "with_#{attr_name}" => '@>',
+        "only_with_#{attr_name}" => '=',
+        "with_any_of_#{attr_name}" => '&&'
+      }.each do |method_name, comparison_operator|
         define_singleton_method(method_name.to_sym) do |values|
           db_values = Array(values).map do |value|
             mapping_hash[value] || raise(ArgumentError, MISSING_VALUE_MESSAGE % {value: value, attr: attr_name})

--- a/test/array_enum_test.rb
+++ b/test/array_enum_test.rb
@@ -28,7 +28,7 @@ class ArrayEnumTest < Minitest::Test
     assert_equal "{1}", user.read_attribute_before_type_cast("favourite_colors")
   end
 
-  # Scope
+  # with_attr scope
   def test_quering_db_with_single_matching_value
     user = User.create!(favourite_colors: ["red"])
     assert_equal [user], User.with_favourite_colors("red")
@@ -71,6 +71,41 @@ class ArrayEnumTest < Minitest::Test
     end
     assert_match(/black is not a valid value for favourite_colors/, error.message)
   end
+
+  # with_any_of_attr scope
+  def test_with_any_of_attr_matching_value
+    user = User.create!(favourite_colors: ["red"])
+    assert_equal [user], User.with_any_of_favourite_colors("red")
+  end
+
+  def test_with_any_of_attr_matching_symbol_value
+    user = User.create!(favourite_colors: ["red"])
+    assert_equal [user], User.with_any_of_favourite_colors(:red)
+  end
+
+  def test_with_any_of_attr_one_of_matching_value
+    user = User.create!(favourite_colors: ["red", "blue"])
+    assert_equal [user], User.with_any_of_favourite_colors("red")
+  end
+
+  def test_with_any_of_attr_excluded_value_does_not_return_record
+    User.create!(favourite_colors: ["red", "blue"])
+    assert_equal [], User.with_any_of_favourite_colors("green")
+  end
+
+  def test_with_any_of_attr_many_value_when_single_match
+    user = User.create!(favourite_colors: ["red", "blue"])
+    assert_equal [user], User.with_any_of_favourite_colors(["red", "green"])
+  end
+
+  def test_with_any_of_attr_by_non_existing_value_raises_error
+    User.create!(favourite_colors: ["red", "blue"])
+    error = assert_raises(ArgumentError) do
+      User.with_any_of_favourite_colors("black")
+    end
+    assert_match(/black is not a valid value for favourite_colors/, error.message)
+  end
+
 
   def test_lists_values
     assert_equal User.favourite_colors, {"red"=>1, "blue"=>2, "green"=>3}


### PR DESCRIPTION
- Adds a scope to retrieve records that have _any_ of the values passed
  in set against them, using Postgres's `&&` operator.
- Refactor duplicated value conversion logic into a lambda