### PR TITLE
Cast appropriate type when generating where query.

### DIFF
--- a/lib/array_enum.rb
+++ b/lib/array_enum.rb
@@ -26,7 +26,7 @@ module ArrayEnum
           db_values = Array(values).map do |value|
             mapping_hash[value] || raise(ArgumentError, format(MISSING_VALUE_MESSAGE, value: value, attr: attr_name))
           end
-          where("#{table_name}.#{attr_name} #{comparison_operator} ARRAY[:db_values]", db_values: db_values)
+          where("#{table_name}.#{attr_name} #{comparison_operator} ARRAY[:db_values]::integer[]", db_values: db_values)
         end
       end
 


### PR DESCRIPTION
This PR:
- Fixes https://github.com/freeletics/array_enum/issues/21
  - Casts the appropriate type when generating the `where` query statement

This fix works for both Rails 7.1 and 7.2